### PR TITLE
fix: change arrow to right when sidebar collapsed

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,3 +139,12 @@
     display: flex;
   }
 }
+
+.collapsedMenuItem {
+  display: none;
+  transform: rotate(180deg);
+
+  @media (min-width: breakpoint.$desktop) {
+    display: flex;
+  }
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,11 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={
+                isSidebarCollapsed
+                  ? styles.collapsedMenuItem
+                  : styles.collapseMenuItem
+              }
             />
           </ul>
         </nav>


### PR DESCRIPTION
Updated the code to change arrow direction to right when sidebar navigation is collapsed.